### PR TITLE
Added 2019.3 support and configurations to do the publishing via gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,12 @@ Example:
 ```groovy
 patchPluginXml {
     changeNotes """
-        The issues #X resolved.<br/>
-        Feature Y added
+        <strong><em>2019-11-28</em></strong>
+        <p>
+        [Bug Fix] : NullPointerException in the IDE log when the description of a spec is going to be updated in the project wizard (#334)
+        [New Feature] : Now developers can choose options X or Y (#223)
+        [Improvements] : The process of doing Z is now faster (#112)
+        </p>
     """
 }
 ```
@@ -63,9 +67,21 @@ This task prepares the final output in `build/distribution` folder as a zip file
 
 **Upload to the marketplace**
 
-This step is manual. You should login to [Upload New Plugin](https://plugins.jetbrains.com/plugin/add/) page in
-JetBrains website using the project account and upload the new version there.
+You can do this step either manually or via gradle.
 
+- Uploading manually
+
+    You should login to [Upload New Plugin](https://plugins.jetbrains.com/plugin/add/) page in JetBrains website using the
+     project account and upload the new version there.
+
+- Upload via gradle
+
+    - Create a Permanent Token with _Marketplace_ scope at [JetBrains Hub](https://hub.jetbrains.com/users/moghaddam?tab=authentification)
+    - Copy the value of the token in an environment variable named _ORG_GRADLE_PROJECT_intellijPublishToken_
+    - Run`./gradlew publishPlugin` in the root of the project to publish the plugin.
+    
+
+Normally it takes two business days until the plugin gets approved and published to the Marketplace.
 
 ## Contributing
 Our [CONTRIBUTING](CONTRIBUTING.md) document contains details for submitting pull requests.

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ patchPluginXml {
     changeNotes """"""
 }
 
+publishPlugin {
+    token = System.getenv("ORG_GRADLE_PROJECT_intellijPublishToken")
+}
+
 wrapper {
     gradleVersion = '5.2.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,13 +19,14 @@
 plugins {
     id 'java'
     id 'checkstyle'
-    id 'org.jetbrains.intellij' version '0.4.10'
+    id 'org.jetbrains.intellij' version '0.4.14'
 }
 
 group 'org.microshed'
-version '0.1.1'
+version '0.1.2'
 
-sourceCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     mavenCentral()
@@ -33,7 +34,7 @@ repositories {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2019.2'
+    version '2019.3'
     plugins 'maven', 'java'
 }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,6 +20,7 @@
 <idea-plugin>
     <id>org.microshed.intellij-plugin</id>
     <name>MicroProfile Starter</name>
+    <idea-version since-build="192" until-build="193.*"/>
 
     <vendor email="zaerymoghaddam@gmail.com" url="https://github.com/MicroShed/mp-starter-intellij-ext">MicroProfile Community</vendor>
 
@@ -40,6 +41,11 @@
 
     <change-notes>
         <![CDATA[
+        <strong><em>2019-11-29</em></strong>
+        <p>
+        [Improvements] : Add support for IntelliJ 2019.3 (#6)
+        </p>
+        <br/>
         <strong><em>2019-11-28</em></strong>
         <p>
         [Bug Fix] : NullPointerException in the IDE log when the description of a spec is going to be updated in the project wizard (#4)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -39,7 +39,12 @@
 ]]></description>
 
     <change-notes>
-        Fixed #4: NullPointerException in the IDE log when the description of a spec is going to be updated in the project wizard
+        <![CDATA[
+        <strong><em>2019-11-28</em></strong>
+        <p>
+        [Bug Fix] : NullPointerException in the IDE log when the description of a spec is going to be updated in the project wizard (#4)
+        </p>
+        ]]>
     </change-notes>
 
     <depends>org.jetbrains.idea.maven</depends>


### PR DESCRIPTION
Updated the build script to support publishing via gradle instead of doing it manually.
Added support for IntelliJ 2019.3 #6 

Signed-off-by: Ehsan Zaery Moghaddam <zaerymoghaddam@gmail.com>