### PR TITLE
Reordering MicroProfile Starter item in the "New Project" wizard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,11 @@ patchPluginXml {
     sinceBuild "201"
     untilBuild "203"
     changeNotes """
+        <strong><em>2020-04-21</em></strong>
+        <p>
+        [Improvements] : Moved MicroProfile Starter icon on "New Project Wizard" to a more relevant section 
+        </p>
+        <br/>
         <strong><em>2020-04-18</em></strong>
         <p>
         [Improvements] : Compatibility with Intellij 2020.* releases 

--- a/src/main/java/org/microshed/intellij/MicroProfileModuleBuilder.java
+++ b/src/main/java/org/microshed/intellij/MicroProfileModuleBuilder.java
@@ -77,7 +77,7 @@ public class MicroProfileModuleBuilder extends JavaModuleBuilder {
 
     @Override
     public String getParentGroup() {
-        return JavaModuleType.BUILD_TOOLS_GROUP;
+        return JavaModuleType.JAVA_GROUP;
     }
 
     @Override
@@ -96,6 +96,12 @@ public class MicroProfileModuleBuilder extends JavaModuleBuilder {
     @Override
     public String getPresentableName() {
         return "MicroProfile Starter";
+    }
+
+    @Override
+    public int getWeight() {
+        //  This ensures the "MicroProfile Starter" appears right after Java/Java EE in Ultimate version
+        return 95;
     }
 
     @Nullable

--- a/src/main/java/org/microshed/intellij/MicroProfileModuleBuilder.java
+++ b/src/main/java/org/microshed/intellij/MicroProfileModuleBuilder.java
@@ -26,6 +26,7 @@ import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext;
 import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.JavaModuleType;
 import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.project.Project;
@@ -76,7 +77,7 @@ public class MicroProfileModuleBuilder extends JavaModuleBuilder {
 
     @Override
     public String getParentGroup() {
-        return "MicroProfile Starter";
+        return JavaModuleType.BUILD_TOOLS_GROUP;
     }
 
     @Override


### PR DESCRIPTION
This commit ensures that the "MicroProfile Starter" would appear in the same section that Java and Java EE modules are located. It's not possible to accurately set the position as it's based on a relative weight value and after that sorted alphanumerically. So in Ultimate version, the order is:

- Java
- Java Enterprise
- JBoss
- MicroProfile Starter

and in the Community edition it's like:

- Java
- MicroProfile Starter

Of course if user has some other extensions installed, those may appear above MicroProfile too.