### PR TITLE
Fixed #10: MicroProfile project wizard is being displayed instead of other Java project types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,12 @@ plugins {
 }
 
 group 'org.microshed'
-version '0.3.1'
+version '0.3.2'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+java  {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
     mavenCentral()
@@ -43,6 +45,11 @@ patchPluginXml {
     sinceBuild "201"
     untilBuild "203"
     changeNotes """
+        <strong><em>2020-05-02</em></strong>
+        <p>
+        [Bug Fix] : MicroProfile project wizard is being displayed instead of other Java project types (#10) 
+        </p>
+        <br/>
         <strong><em>2020-04-21</em></strong>
         <p>
         [Improvements] : Moved MicroProfile Starter icon on "New Project Wizard" to a more relevant section 

--- a/src/main/java/org/microshed/intellij/MicroProfileCompatibleJavaModuleType.java
+++ b/src/main/java/org/microshed/intellij/MicroProfileCompatibleJavaModuleType.java
@@ -22,29 +22,61 @@ import com.intellij.ide.util.projectWizard.JavaSettingsStep;
 import com.intellij.ide.util.projectWizard.ModuleBuilder;
 import com.intellij.ide.util.projectWizard.ModuleWizardStep;
 import com.intellij.ide.util.projectWizard.SettingsStep;
-import com.intellij.openapi.module.JavaModuleType;
 import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.module.ModuleTypeManager;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.util.lang.JavaVersion;
+import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
 
 /**
  * @author Ehsan Zaery Moghaddam (ezm@one.com)
  */
-public class MicroProfileCompatibleJavaModuleType extends JavaModuleType {
+public class MicroProfileCompatibleJavaModuleType extends ModuleType<MicroProfileModuleBuilder> {
+    private static final String MICROPROFILE_MODULE_ID = "MICROPROFILE_MODULE";
 
-    public static final ModuleType JAVA;
+    public MicroProfileCompatibleJavaModuleType() {
+        super(MICROPROFILE_MODULE_ID);
+    }
 
-    static {
-        try {
-            JAVA = (ModuleType) Class.forName("org.microshed.intellij." +
-                    "MicroProfileCompatibleJavaModuleType").newInstance();
-        } catch (Exception e) {
-            throw new IllegalArgumentException(e);
-        }
+    protected MicroProfileCompatibleJavaModuleType(@NotNull String id) {
+        super(id);
+    }
+
+    public static ModuleType getModuleType() {
+        return ModuleTypeManager.getInstance().findByID(MICROPROFILE_MODULE_ID);
+    }
+
+    @NotNull
+    @Override
+    public MicroProfileModuleBuilder createModuleBuilder() {
+        return new MicroProfileModuleBuilder();
+    }
+
+    @Nls(capitalization = Nls.Capitalization.Title)
+    @NotNull
+    @Override
+    public String getName() {
+        return "MicroProfile Starter";
+    }
+
+    @Nls(capitalization = Nls.Capitalization.Sentence)
+    @NotNull
+    @Override
+    public String getDescription() {
+        return "A MicroProfile module is used to start developing microservices using MicroProfile. It uses MicroProfile Starter to setup proper " +
+                "dependencies and configurations based on the MicroProfile runtime that you choose.";
+    }
+
+    @NotNull
+    @Override
+    public Icon getNodeIcon(boolean isOpened) {
+        return MicroProfilePluginIcons.MICROPROFILE_ICON;
     }
 
     @Nullable

--- a/src/main/java/org/microshed/intellij/MicroProfileModuleBuilder.java
+++ b/src/main/java/org/microshed/intellij/MicroProfileModuleBuilder.java
@@ -72,7 +72,7 @@ public class MicroProfileModuleBuilder extends JavaModuleBuilder {
 
     @Override
     public ModuleType getModuleType() {
-        return MicroProfileCompatibleJavaModuleType.JAVA;
+        return MicroProfileCompatibleJavaModuleType.getModuleType();
     }
 
     @Override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -43,5 +43,6 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <moduleBuilder builderClass="org.microshed.intellij.MicroProfileModuleBuilder" order="last" id="MICRO_PROFILE_MODULE_BUILDER"/>
+        <moduleType implementationClass="org.microshed.intellij.MicroProfileCompatibleJavaModuleType" id="MICROPROFILE_MODULE"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
This PR fixes issue #10 by introducing the MicroProfile Starter as an standalone module type instead of declaring it as a JavaModuleType.

It also ensures that the MicroProfile icon would be displayed for the project in the project tree.