### PR TITLE
Added model field to handle API response

### DIFF
--- a/src/main/java/org/microshed/intellij/model/MicroProfileConfig.java
+++ b/src/main/java/org/microshed/intellij/model/MicroProfileConfig.java
@@ -27,6 +27,15 @@ import java.util.List;
 public class MicroProfileConfig {
     private List<String> supportedServers = new ArrayList<>();
     private List<String> specs = new ArrayList<>();
+    private List<String> specCodes = new ArrayList<>();
+
+    public List<String> getSpecCodes() {
+        return specCodes;
+    }
+
+    public void setSpecCodes(List<String> specCodes) {
+        this.specCodes = specCodes;
+    }
 
     public List<String> getSupportedServers() {
         return supportedServers;


### PR DESCRIPTION
The missing `specCodes` property is causing the returned JSON to not be parsed successfully resulting in an error